### PR TITLE
Add time to intro post

### DIFF
--- a/_posts/2024-04-28-introducing-the-svunit-blog.md
+++ b/_posts/2024-04-28-introducing-the-svunit-blog.md
@@ -1,5 +1,6 @@
 ---
 title: "Introducing the SVUnit Blog"
+date: 2024-04-28 19:56:00 +0200
 ---
 
 Every now and then,


### PR DESCRIPTION
Even though we're not displaying the time on the site, we might want to do it in the future.

Having a time makes it possible to sort blog posts which are published on the same day. It's not super common, but it has happened on other blogs.